### PR TITLE
Fixes an edge case

### DIFF
--- a/AutotaskCLI/public/SoapProxy.ps1
+++ b/AutotaskCLI/public/SoapProxy.ps1
@@ -36,7 +36,7 @@ function Get-AutoTaskObject {
 
             # Building the Splat
             $ProxyParams = @{
-                Uri        = [Uri]::new($ZoneInfo.URL.replace('.asmx', '.wsdl'))
+                Uri        = [Uri]::new($ZoneInfo.URL.replace('.asmx', '.wsdl')).AbsoluteUri
                 Credential = $Credential
                 #Namespace  = $Namespace
             }


### PR DESCRIPTION
In rare instantes New-WebServiceProxy wasn't picking AbsoluteUri for the
Uri parameter.